### PR TITLE
Update TableUtil.cs

### DIFF
--- a/Client/Assets/Scripts/Util/TableUtil.cs
+++ b/Client/Assets/Scripts/Util/TableUtil.cs
@@ -7,7 +7,7 @@ public class TableUtil
     
     public static int[] LoadInts(string data)
     {
-        int[] decodeData = JsonUtility.FromJson<int[]>(data);
+        int[] decodeData = FromJson<int[]>(data);
         return decodeData;
     }
 
@@ -16,5 +16,28 @@ public class TableUtil
     {
         Dictionary<string, int> decodeData = JsonUtility.FromJson<Dictionary<string, int>>(data);
         return decodeData;
+    }
+    
+    /// <summary> 解析Json </summary>
+    /// <typeparam name="T">类型</typeparam>
+    /// <param name="json">Json字符串</param>
+    public static T FromJson<T>(string json)
+    {
+        if (json == "null" && typeof(T).IsClass) return default(T);
+
+        if (typeof(T).GetInterface("IList") != null)
+        {
+            json = "{\"data\":{data}}".Replace("{data}", json);
+            Pack<T> Pack = JsonUtility.FromJson<Pack<T>>(json);
+            return Pack.data;
+        }
+
+        return JsonUtility.FromJson<T>(json);
+    }
+
+    /// <summary> 内部包装类 </summary>
+    private class Pack<T>
+    {
+        public T data;
     }
 }


### PR DESCRIPTION
unity自带json的坑，转int数组不能直接用JsonUtility.FromJson，否则会报错，详见https://segmentfault.com/a/1190000018597262